### PR TITLE
Secure api keys in code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore secrets and local configs
+config.js
+.env
+.env.local
+*.local
+node_modules/
+dist/
+build/
+.DS_Store
+Thumbs.db

--- a/admin.html
+++ b/admin.html
@@ -10,6 +10,7 @@
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
 <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
+<script src="config.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
@@ -1822,15 +1823,11 @@
 </div>
 <script>
 // Configuração do Firebase
-const firebaseConfig = {
-  apiKey: "AIzaSyCcAKzyiCnuTAke9_Emf6omH6qrjCp99YI",
-  authDomain: "reservas-eun.firebaseapp.com",
-  projectId: "reservas-eun",
-  storageBucket: "reservas-eun.firebasestorage.app",
-  messagingSenderId: "532255616856",
-  appId: "1:532255616856:web:02de05202653e31022bf2d"
-};
-firebase.initializeApp(firebaseConfig);
+if (!window.firebaseConfig) {
+  console.error('config.js não carregado: defina window.firebaseConfig.');
+  alert('Configuração do Firebase ausente. Verifique o arquivo config.js.');
+}
+firebase.initializeApp(window.firebaseConfig);
 const db = firebase.firestore();
 const auth = firebase.auth();
 

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,12 @@
+// Copie este arquivo para config.js e preencha com seus valores reais.
+// NUNCA commite o arquivo config.js ao repositório.
+
+window.firebaseConfig = {
+  apiKey: "COLOQUE_SUA_API_KEY_AQUI",
+  authDomain: "SEU_PROJETO.firebaseapp.com",
+  projectId: "SEU_PROJETO",
+  storageBucket: "SEU_PROJETO.appspot.com",
+  messagingSenderId: "000000000000",
+  appId: "1:000000000000:web:xxxxxxxxxxxxxxxxxxxxxx"
+};
+

--- a/index.html
+++ b/index.html
@@ -881,16 +881,13 @@
 </div>
 <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
+<script src="config.js"></script>
 <script>
-    const firebaseConfig = {
-      apiKey: "AIzaSyCcAKzyiCnuTAke9_Emf6omH6qrjCp99YI",
-  authDomain: "reservas-eun.firebaseapp.com",
-  projectId: "reservas-eun",
-  storageBucket: "reservas-eun.firebasestorage.app",
-  messagingSenderId: "532255616856",
-  appId: "1:532255616856:web:02de05202653e31022bf2d"
-    };
-    firebase.initializeApp(firebaseConfig);
+    if (!window.firebaseConfig) {
+      console.error('config.js não carregado: defina window.firebaseConfig.');
+      alert('Configuração do Firebase ausente. Verifique o arquivo config.js.');
+    }
+    firebase.initializeApp(window.firebaseConfig);
     const db = firebase.firestore();
 
     const STATUS_OPTIONS = [


### PR DESCRIPTION
Externalize Firebase configuration to `config.js` and add it to `.gitignore` to prevent hardcoded keys from being committed.

---
<a href="https://cursor.com/background-agent?bcId=bc-497032c8-e7fe-4525-8f01-a345c4bf2502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-497032c8-e7fe-4525-8f01-a345c4bf2502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

